### PR TITLE
feat(vn): buffer quest actions and outcomes

### DIFF
--- a/client/src/entities/visual-novel/model/hooks.ts
+++ b/client/src/entities/visual-novel/model/hooks.ts
@@ -1,7 +1,7 @@
 import { useVNStore } from './store'
 import type { GameState } from './types'
 import { useNavigate } from 'react-router-dom'
-import { questsApi, qrApi } from '@/shared/api/quests'
+import { qrApi } from '@/shared/api/quests'
 import { getQuestMeta } from '@/entities/quest/model/catalog'
 import { useProgressionStore } from '@/entities/quest/model/progressionStore'
 
@@ -48,17 +48,15 @@ export const useSceneEngine = () => {
           // eslint-disable-next-line no-console
           console.warn('[VN] grant PDA failed', e)
         }
-        // ВАЖНО: сначала поднимаем фазу на сервере (иначе старт квеста заблокирован на phase 0)
-        try { await questsApi.setPlayerPhase(1) } catch (e) {
-          // eslint-disable-next-line no-console
-          console.warn('[VN] setPlayerPhase failed', e)
-        }
         const meta = getQuestMeta('delivery_and_dilemma' as any)
+        actions.addPendingAction({ type: 'outcome', setPhase: 1 })
         if (meta) {
-          try { await questsApi.startQuest('delivery_and_dilemma' as any, meta.startStep as any) } catch (e) {
-            // eslint-disable-next-line no-console
-            console.warn('[VN] startQuest failed', e)
-          }
+          actions.addPendingAction({
+            type: 'quest',
+            op: 'start',
+            questId: 'delivery_and_dilemma',
+            step: meta.startStep as any,
+          })
         }
         // Синхронизируем локально для UI
         setPhase(1)
@@ -70,7 +68,33 @@ export const useSceneEngine = () => {
     return false
   }
 
-  return { handleInlineActions, setScene: actions.setScene }
+  const choose = (choiceId: string) => {
+    const state = useVNStore.getState()
+    const scene = state.scenes[state.game.currentSceneId]
+    const choice = scene?.choices?.find((c) => c.id === choiceId)
+    if (choice) {
+      const quest = (choice as any).quest as {
+        op: 'start' | 'advance' | 'complete'
+        id: string
+        step?: string
+      } | undefined
+      const outcome = (choice as any).outcome as Record<string, unknown> | undefined
+      if (quest) {
+        actions.addPendingAction({
+          type: 'quest',
+          op: quest.op,
+          questId: quest.id,
+          step: quest.step,
+        })
+      }
+      if (outcome) {
+        actions.addPendingAction({ type: 'outcome', ...outcome })
+      }
+    }
+    actions.choose(choiceId)
+  }
+
+  return { handleInlineActions, setScene: actions.setScene, choose }
 }
 
 

--- a/client/src/entities/visual-novel/model/store.ts
+++ b/client/src/entities/visual-novel/model/store.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand'
-import type { GameActions, GameState, Scene } from './types'
+import { questsApi } from '@/shared/api/quests'
+import type { GameActions, GameState, Scene, PendingAction } from './types'
 
 interface VNState {
   game: GameState
   scenes: Record<string, Scene>
+  pendingActions: PendingAction[]
   actions: GameActions
 }
 
@@ -19,6 +21,7 @@ export const createInitialGameState = (startScene: string): GameState => ({
 export const useVNStore = create<VNState>((set, get) => ({
   game: createInitialGameState('station_intro'),
   scenes: {},
+  pendingActions: [],
   actions: {
     setScene: (sceneId) =>
       set((s) => ({ game: { ...s.game, currentSceneId: sceneId, lineIndex: 0 } })),
@@ -58,6 +61,30 @@ export const useVNStore = create<VNState>((set, get) => ({
     setFlag: (key, value) => set((s) => ({ game: { ...s.game, flags: { ...s.game.flags, [key]: value } } })),
     reset: (sceneId) => set({ game: createInitialGameState(sceneId) }),
     hydrate: (state) => set({ game: state }),
+    addPendingAction: (action) =>
+      set((s) => ({ pendingActions: [...s.pendingActions, action] })),
+    flushPendingActions: async () => {
+      const { pendingActions } = get()
+      if (pendingActions.length === 0) return
+      try {
+        for (const act of pendingActions) {
+          if (act.type === 'quest') {
+            if (act.op === 'start' && act.step)
+              await questsApi.startQuest(act.questId, act.step)
+            if (act.op === 'advance' && act.step)
+              await questsApi.advanceQuest(act.questId, act.step)
+            if (act.op === 'complete') await questsApi.completeQuest(act.questId)
+          } else if (act.type === 'outcome') {
+            const { type: _t, ...payload } = act
+            await questsApi.applyOutcome(payload)
+          }
+        }
+        set({ pendingActions: [] })
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('[VN] flushPendingActions failed', e)
+      }
+    },
   },
 }))
 

--- a/client/src/entities/visual-novel/model/types.ts
+++ b/client/src/entities/visual-novel/model/types.ts
@@ -50,6 +50,26 @@ export interface Item {
   title: string
 }
 
+export type PendingAction =
+  | {
+      type: 'quest'
+      op: 'start' | 'advance' | 'complete'
+      questId: string
+      step?: string
+    }
+  | {
+      type: 'outcome'
+      fameDelta?: number
+      reputationsDelta?: Record<string, number>
+      relationshipsDelta?: Record<string, number>
+      addFlags?: string[]
+      removeFlags?: string[]
+      addWorldFlags?: string[]
+      removeWorldFlags?: string[]
+      setPhase?: number
+      setStatus?: string
+    }
+
 export interface GameState {
   currentSceneId: string
   lineIndex: number
@@ -66,6 +86,8 @@ export interface GameActions {
   setFlag: (key: string, value: boolean) => void
   reset: (sceneId: string) => void
   hydrate: (state: GameState) => void
+  addPendingAction: (action: PendingAction) => void
+  flushPendingActions: () => Promise<void>
 }
 
 

--- a/client/src/entities/visual-novel/ui/parts/ChoiceMenu.tsx
+++ b/client/src/entities/visual-novel/ui/parts/ChoiceMenu.tsx
@@ -1,12 +1,12 @@
 import type { Choice } from '@/entities/visual-novel/model/types'
-import { useVNStore } from '@/entities/visual-novel/model/store'
+import { useSceneEngine } from '@/entities/visual-novel/model/hooks'
 
 interface Props {
   choices: Choice[]
 }
 
 export function ChoiceMenu({ choices }: Props) {
-  const choose = useVNStore((s) => s.actions.choose)
+  const { choose } = useSceneEngine()
   if (!choices.length) return null
   return (
     <div className="absolute bottom-28 left-0 right-0 flex flex-col gap-2 items-center">


### PR DESCRIPTION
## Summary
- add pending actions buffer and flusher in VN store
- queue quest operations and outcomes when selecting branches
- route choice menu through scene engine

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-boundaries')*


------
https://chatgpt.com/codex/tasks/task_e_68acb5699de0832e880b488905574fed